### PR TITLE
fix: fix read split buffer function gr block bug

### DIFF
--- a/example/dubbo/go-client/cmd/client.go
+++ b/example/dubbo/go-client/cmd/client.go
@@ -20,6 +20,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -47,10 +50,13 @@ var greeterProvider = new(pkg.GreeterClientImpl)
 
 func init() {
 	config.SetConsumerService(greeterProvider)
+	runtime.SetMutexProfileFraction(1)
 }
-
 // need to setup environment variable "CONF_CONSUMER_FILE_PATH" to "conf/client.yml" before run
 func main() {
+	go func() {
+		_ = http.ListenAndServe("0.0.0.0:6061", nil)
+	}()
 	config.Load()
 	time.Sleep(time.Second * 3)
 	testSayHello()
@@ -94,7 +100,7 @@ func testSayHelloWithHighParallel() {
 		wg := sync.WaitGroup{}
 		goodCounter := atomic.Uint32{}
 		badCounter := atomic.Uint32{}
-		for i := 0; i < 1000; i ++{
+		for i := 0; i < 2000; i ++{
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/example/dubbo/go-server/cmd/server.go
+++ b/example/dubbo/go-server/cmd/server.go
@@ -19,8 +19,11 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 )
@@ -36,20 +39,28 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/registry/nacos"
 	_ "dubbo.apache.org/dubbo-go/v3/registry/protocol"
 	_ "dubbo.apache.org/dubbo-go/v3/registry/zookeeper"
+
+	_ "github.com/dubbogo/triple/pkg/triple"
 )
 
 import (
 	"github.com/dubbogo/triple/example/dubbo/go-server/pkg"
-	_ "github.com/dubbogo/triple/pkg/triple"
 )
 
 var (
 	survivalTimeout = int(3 * time.Second)
 )
 
+func init() {
+	runtime.SetMutexProfileFraction(1)
+}
+
 // need to setup environment variable "CONF_PROVIDER_FILE_PATH" to "conf/server.yml" before run
 func main() {
 	config.SetProviderService(pkg.NewGreeterProvider())
+	go func() {
+		_ = http.ListenAndServe("0.0.0.0:6060", nil)
+	}()
 	config.Load()
 	initSignal()
 }

--- a/example/go.mod
+++ b/example/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	dubbo.apache.org/dubbo-go/v3 v3.0.0-rc2
-	github.com/dubbogo/gost v1.11.16
 	github.com/dubbogo/triple v1.0.1
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.7.0

--- a/pkg/http2/client.go
+++ b/pkg/http2/client.go
@@ -2,6 +2,7 @@ package http2
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -84,7 +85,7 @@ func (h *Client) StreamPost(addr, path string, sendChan chan *bytes.Buffer, opts
 			close(closeChan)
 			return
 		}
-		ch := readSplitData(rsp.Body)
+		ch := readSplitData(context.Background(), rsp.Body)
 	Loop:
 		for {
 			select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:
When I using pprof to check gr leak bug, I found that function `readSplitData` would block when gr pool full. And I solve it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```