### PR TITLE
Remove obsolete unit test code.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,15 +71,9 @@ func TestOption_SetEmptyFieldDefaultConfig(t *testing.T) {
 	)
 	assert.NotNil(t, opt)
 	assert.Equal(t, uint32(100000), opt.BufferSize)
-	assert.Equal(t, uint32(0), opt.Timeout)
-	opt.Validate()
-	assert.Equal(t, uint32(100000), opt.BufferSize)
 	assert.Equal(t, uint32(constant.DefaultTimeout), opt.Timeout)
 
 	opt = NewTripleOption()
-	assert.Equal(t, uint32(0), opt.BufferSize)
-	assert.Equal(t, uint32(0), opt.Timeout)
-	opt.Validate()
 	assert.Equal(t, uint32(constant.DefaultHttp2ControllerReadBufferSize), opt.BufferSize)
 	assert.Equal(t, uint32(constant.DefaultTimeout), opt.Timeout)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:

The unit test code in `config_test.go` cannot be passed because of the [previous modification](https://github.com/dubbogo/triple/commit/b51f4de275ff5cece39b3cd10cfb8d4275bfb1a1) in

 `config.go: NewTripleOption`.

The `Validate` function will be called in `NewTripleOption`. So the default value in `opt` are not zeros.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```